### PR TITLE
Fixed issue with preview crashing for PetProfileView and PetListView

### DIFF
--- a/SniffServe/Views/PetListView.swift
+++ b/SniffServe/Views/PetListView.swift
@@ -8,13 +8,11 @@
 import SwiftUI
 
 struct PetListView: View {
-    @EnvironmentObject var dogViewModel: DogViewModel
-    
     var body: some View {
         BaseView(
             topRightIcon: "plus"
         ) {
-            MainBodyView().environmentObject(dogViewModel)
+            MainBodyView()
         }
     }
 }
@@ -57,8 +55,6 @@ struct DogListView: View {
 
 struct PetListView_Previews: PreviewProvider {
     static var previews: some View {
-        return NavigationStack {
-            PetListView()
-        }
+        PetListView()
     }
 }

--- a/SniffServe/Views/PetProfileView.swift
+++ b/SniffServe/Views/PetProfileView.swift
@@ -159,16 +159,14 @@ struct PetProfileView_Previews: PreviewProvider {
     static var previews: some View {
         let dogViewModel = DogViewModel()
 
-        return NavigationStack {
-            PetProfileView(dog: dogViewModel.dogs.first ?? Dog(
-                name: "Daisy",
-                breed: "French Bulldog",
-                age_years: 14,
-                gender: "Female",
-                chronic_conditions: ["Blind in one eye", "Kidney issues", "Trouble walking"]
-            ))
-            .environmentObject(dogViewModel)
-        }
+        PetProfileView(dog: dogViewModel.dogs.first ?? Dog(
+            name: "Daisy",
+            breed: "French Bulldog",
+            age_years: 14,
+            gender: "Female",
+            chronic_conditions: ["Blind in one eye", "Kidney issues", "Trouble walking"]
+        ))
+        .environmentObject(dogViewModel)
     }
 }
 


### PR DESCRIPTION
PetProfileView and PetListView did not like returning view inside of a NavigationStack component which was causing crashes. Should be fixed now.